### PR TITLE
Update examples

### DIFF
--- a/lib/jsvat.js
+++ b/lib/jsvat.js
@@ -1,91 +1,13 @@
+/* 
+ * Copyright (C) 2013 Akkroo Solutions Ltd
+ * 
+ */
+
+
 /*==================================================================================================
 
-Application:   Utility Function
-Author:        John Gardner
-
-Version:       V1.0
-Date:          30th July 2005
-Description:   Used to check the validity of an EU country VAT number
-
-Version:       V1.1
-Date:          3rd August 2005
-Description:   Lithunian legal entities & Maltese check digit checks added.
-
-Version:       V1.2
-Date:          20th October 2005
-Description:   Italian checks refined (thanks Matteo Mike Peluso).
-
-Version:       V1.3
-Date:          16th November 2005
-Description:   Error in GB numbers ending in 00 fixed (thanks Guy Dawson).
-
-Version:       V1.4
-Date:          28th September 2006
-Description:   EU-type numbers added.
-
-Version:       V1.5
-Date:          1st January 2007
-Description:   Romanian and Bulgarian numbers added.
-
-Version:       V1.6
-Date:          7th January 2007
-Description:   Error with Slovenian numbers (thanks to Ales Hotko).
-
-Version:       V1.7
-Date:          10th February 2007
-Description:   Romanian check digits added. Thanks to Dragu Costel for test suite.
-
-Version:       V1.8
-Date:          3rd August 2007
-Description:   IE code modified to allow + and * in old format numbers. Thanks to Antonin Moy of 
-               Spehere Solutions for pointing out the error.
-
-Version:       V1.9
-Date:          6th August 2007
-Description:   BE code modified to make a specific check that the leading character of 10 digit 
-               numbers is 0 (belts and braces).
-
-Version:       V1.10
-Date:          10th August 2007
-Description:   Cypriot check digit support added.
-               Check digit validation support for non-standard UK numbers
-
-Version:       V1.11
-Date:          25th September 2007
-Description:   Spain check digit support for personal numbers.
-               Author: David Perez Carmona
-
-Version:       V1.12
-Date:          23rd November 2009
-Description:   GB code modified to take into account new style check digits.
-               Thanks to Guy Dawson of Crossflight Ltd for pointing out the necessity.
-
-Version:       V1.13
-Date:          7th July 2012
-Description:   EL, GB, SE and BE formats updated - thanks to Joost Van Biervliet
-
-Version:       V.14
-Date:          8th April 2013
-Description:   BE Pattern match refined
-               BG Add check digit checks for all four types of VAT number
-               CY Pattern match improved
-               CZ Personal pattern match checking improved
-               CZ Personal check digits incorporated
-               EE improved pattern match
-               ES Physical person number checking refined
-               GB Check digit support provided for 12 digit VAT codes and range checks included
-               IT Bug removed to allow 999 and 888 issuing office codes
-               LT temporarily registered taxpayers check digit support added
-               LV Natural persons checks added
-               RO improved pattern match
-               SK improved pattern match and added check digit support
-               
-               Thanks to Theo Vroom for his help in this latest release.
-               
-Version:      V1.15
-Date:         15th April 2013
-              Swedish algorithm re-implemented.
-               
+Application:  Utility Function
+Author:       John Gardner
 Version:      V1.16
 Date:         25th July 2013
               Support for Croatian numbers added
@@ -99,7 +21,9 @@ returns the VAT number re-formatted.
   
 Example call:
   
-  if (checkVATNumber (myVATNumber)) 
+  var checkVATObject = checkVATNumber(myVATNumber, countryCode);
+  
+  if (checkVATObject.valid_vat) 
       alert ("VAT number has a valid format")
   else 
       alert ("VAT number has invalid format");
@@ -120,7 +44,7 @@ function checkVATNumber (toCheck, country_code) {
   
   var defCCode = "GB";
   
-  country_code = country_code.trim().toUpperCase();
+  country_code = country_code.replace(/\s*/gi,"").toUpperCase();
   toCheck = toCheck.replace(/\s*/gi,"");
 
   // Note - VAT codes without the "**" in the comment do not have check digit checking.
@@ -1419,5 +1343,4 @@ function UKVATCheckDigit (vatnumber) {
   else
     return false; 
 }
-
 


### PR DESCRIPTION
Hi,

Just thought id let you know that you documentation doesn't seem to match what you have in libs.

CheckVATNumber requires you to pass two parameters in your example below: 

"if (checkVATNumber (myVATNumber)) 
      alert ("VAT number has a valid format")
  else 
      alert ("VAT number has invalid format");
"

checkVATNumber returns an object not a true of false value. `checkVATForGivenCountryCode` function does not exist too.

Stripped down the versions, to just the most recent.

Last thing, the .trim() function is not supported in IE8. Replaced with replace.  
http://stackoverflow.com/questions/2308134/trim-in-javascript-not-working-in-ie
